### PR TITLE
Update mqtt-launcher.py

### DIFF
--- a/mqtt-launcher.py
+++ b/mqtt-launcher.py
@@ -151,9 +151,6 @@ if __name__ == '__main__':
 
     mqttc.connect(cf.get('mqtt_broker', 'localhost'), int(cf.get('mqtt_port', '1883')), 60)
 
-    for topic in topiclist:
-        mqttc.subscribe(topic, qos)
-
     while True:
         try:
             mqttc.loop_forever()


### PR DESCRIPTION

Fixes #15

> starting the program, the client subscribes twice to the topics. This leads to a repeated execution of commands for retained messages.
> 
> subscription is done in on_connect(...) and again in line 154

> There is no reason, and I'm not sure how that slipped in. You should be able to safely remove 154/155, and I'll accept a PR for it. :-)